### PR TITLE
Pin dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import * as THREE from "https://unpkg.com/three/build/three.module.js";
-import { OrbitControls } from "https://unpkg.com/three/examples/jsm/controls/OrbitControls.js";
+import * as THREE from "https://unpkg.com/three@0.127.0/build/three.module.js";
+import { OrbitControls } from "https://unpkg.com/three@0.127.0/examples/jsm/controls/OrbitControls.js";
 import { clothFunction, xSegs, ySegs, MASS } from "./lib.js";
 import { Cloth } from "./cloth.js";
 

--- a/particle.js
+++ b/particle.js
@@ -1,4 +1,4 @@
-import { Vector3 } from "https://unpkg.com/three/build/three.module.js";
+import { Vector3 } from "https://unpkg.com/three@0.127.0/build/three.module.js";
 import { DRAG, clothFunction } from "./lib.js";
 
 export function Particle(x, y, z, mass) {


### PR DESCRIPTION
Fix cause `TypeError: Failed to resolve module specifier "three". Relative references must start with either "/", "./", or "../"` when use >= r128